### PR TITLE
Filter out MacOS .DS_Store file when reading assets

### DIFF
--- a/cider-app/src/app/data-services/electron/electron.service.ts
+++ b/cider-app/src/app/data-services/electron/electron.service.ts
@@ -182,7 +182,7 @@ export class ElectronService {
     await cardsService.emptyTable();
     await decksService.emptyTable();
     await this.listDirectory(assetsUrl).then(assetUrls => Promise.all(assetUrls
-      .filter(assetUrl => assetUrl.isFile).map(async assetUrl => {
+      .filter(assetUrl => assetUrl.isFile && !assetUrl.name.includes('.DS_Store')).map(async assetUrl => {
       const assetNameSplit = StringUtils.splitNameAndExtension(assetUrl.name);
       const assetName = assetNameSplit.name;
       const assetExt = assetNameSplit.extension;


### PR DESCRIPTION
When making manual changes inside the assets folder, MacOS will add in a .DS_Store file which then messes up the asset import/rendering.