### PR TITLE
Encode buffer into UTF-8 string when importing .csv

### DIFF
--- a/cider-app/src/app/shared/utils/xlsx-utils.ts
+++ b/cider-app/src/app/shared/utils/xlsx-utils.ts
@@ -63,7 +63,9 @@ export default class XlsxUtils {
         file: File): Promise<Entity[]> {
         const headers = columns.filter(column => !column.hidden);
         return file.arrayBuffer().then(buffer => {
-            const workbook: XLSX.WorkBook = XLSX.read(buffer, {type: "buffer"});
+            const decoder = new TextDecoder("utf-8");
+            const decoded = decoder.decode(buffer);
+            const workbook: XLSX.WorkBook = XLSX.read(decoded, {type: "string"});
             const worksheet: XLSX.WorkSheet = workbook.Sheets[workbook.SheetNames[0]];
             const parsedObjects = XLSX.utils.sheet_to_json(worksheet);
             const convertedObjects = parsedObjects.map(object => {


### PR DESCRIPTION
When importing .csv files, the buffer is left as is when read by XSLX.read, leading to broken text encoding.

This is the first Javascript stuff I have done, and I already hate it. :+1: Took me ages to google something that worked, but this seems to do the trick.