### PR TITLE
Add custom variables for reuse across templates

### DIFF
--- a/cider-app/src/app/app-routing.module.ts
+++ b/cider-app/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import { DeckGuard } from './deck.guard';
 import { DecksComponent } from './decks/decks.component';
 import { WelcomeComponent } from './welcome/welcome.component';
 import { ProjectGuard } from './project.guard';
+import { VariablesComponent } from './variables/variables.component';
 
 const routes: Routes = [
   { path: 'decks', component: DecksComponent, canActivate: [ProjectGuard]},
@@ -20,6 +21,7 @@ const routes: Routes = [
   { path: 'decks/:deckId/cards/attributes', component: CardAttributesComponent, canActivate: [ProjectGuard, DeckGuard]},
   { path: 'decks/:deckId/card-templates', component: CardTemplatesComponent, canActivate: [ProjectGuard, DeckGuard]},
   { path: 'decks/:deckId/export-cards', component: ExportCardsComponent, canActivate: [ProjectGuard, DeckGuard]},
+  { path: 'variables', component: VariablesComponent, canActivate: [ProjectGuard]},
   { path: '**', component: WelcomeComponent}
 ];
 

--- a/cider-app/src/app/app.module.ts
+++ b/cider-app/src/app/app.module.ts
@@ -58,6 +58,7 @@ import { PageHeaderComponent } from './page-header/page-header.component';
 import { WelcomeComponent } from './welcome/welcome.component';
 import { ExportSelectionDialogComponent } from './export-selection-dialog/export-selection-dialog.component';
 import { CardToHtmlPipe } from './shared/pipes/template-to-html.pipe';
+import { VariablesComponent } from './variables/variables.component';
 
 @NgModule({
   declarations: [
@@ -77,6 +78,7 @@ import { CardToHtmlPipe } from './shared/pipes/template-to-html.pipe';
     CardsTabMenuComponent,
     CardAttributesComponent,
     CardThumbnailsComponent,
+    VariablesComponent,
     PageHeaderComponent,
     WelcomeComponent,
     ExportSelectionDialogComponent

--- a/cider-app/src/app/card-preview/card-preview.component.html
+++ b/cider-app/src/app/card-preview/card-preview.component.html
@@ -9,6 +9,6 @@
     <div *ngIf="!(cache && cachedImageUrl)" [style.transform]="'scale(' + scale + ')'"
         class="card-preview card-{{uuid}}{{lowInk ? ' low-ink' : ''}}" >
         <div #cardElement class="card-element" 
-            [innerHtml]="template | cardToHtml: card: assetUrls: uuid" ></div>
+            [innerHtml]="template | cardToHtml: card: assetUrls: uuid: variables" ></div>
     </div>
 </div>

--- a/cider-app/src/app/card-preview/card-preview.component.ts
+++ b/cider-app/src/app/card-preview/card-preview.component.ts
@@ -9,6 +9,8 @@ import { CardToHtmlPipe } from '../shared/pipes/template-to-html.pipe';
 import * as htmlToImage from 'html-to-image';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import GeneralUtils from '../shared/utils/general-utils';
+import { VariablesService } from '../data-services/services/variables.service';
+import { Variable, VariableCollection } from '../data-services/types/variable.type';
 
 @Component({
   selector: 'app-card-preview',
@@ -25,6 +27,7 @@ export class CardPreviewComponent implements OnInit, AfterViewChecked, OnChanges
   initialWidth: number = 0;
   initialHeight: number = 0;
   assetUrls: any;
+  variables?: VariableCollection;
   uuid: string  = uuid();
   cachedImageUrl?: string;
   private isLoadedSubject: AsyncSubject<boolean>;
@@ -32,6 +35,7 @@ export class CardPreviewComponent implements OnInit, AfterViewChecked, OnChanges
 
   constructor(
     private assetsService: AssetsService,
+    private variablesService: VariablesService,
     private renderCacheService: RenderCacheService,
     private element: ElementRef,
     private changeDetectorRef: ChangeDetectorRef,
@@ -39,6 +43,7 @@ export class CardPreviewComponent implements OnInit, AfterViewChecked, OnChanges
     private sanitizer: DomSanitizer) { 
       this.isLoadedSubject = new AsyncSubject();
       this.isCacheLoadedSubject = new AsyncSubject();
+      variablesService.getCollection().then(vars => this.variables = vars);
   }
 
   /**

--- a/cider-app/src/app/data-services/services/variables.service.spec.ts
+++ b/cider-app/src/app/data-services/services/variables.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { VariablesService } from './variables.service';
+
+describe('VariablesService', () => {
+  let service: VariablesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(VariablesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/cider-app/src/app/data-services/services/variables.service.ts
+++ b/cider-app/src/app/data-services/services/variables.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { AppDB } from '../indexed-db/db';
+import { FieldType } from '../types/field-type.type';
+import { IndexedDbService } from '../indexed-db/indexed-db.service';
+import { Variable, VariableCollection } from '../types/variable.type';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class VariablesService extends IndexedDbService<Variable, number> {
+
+  constructor(db: AppDB) {
+    super(db, AppDB.VARIABLES_TABLE, [
+      {field: 'id', header: 'ID', type: FieldType.number, hidden: true},
+      {field: 'name', header: 'Name', type: FieldType.text, description: 'The name of the variable'},
+      {field: 'value', header: 'Value', type: FieldType.text, description: 'The value of the variable'},
+    ]);
+  }
+  
+  override getEntityName(entity: Variable) {
+    return entity.name;
+  }
+
+  getCollection(): Promise<VariableCollection> {
+    return this.getAll().then(variablesArray => {
+      let collection:VariableCollection = {};
+      variablesArray.forEach(variable => collection[variable.name] = variable.value);
+      return collection;
+    })
+  }
+}

--- a/cider-app/src/app/data-services/types/variable.type.ts
+++ b/cider-app/src/app/data-services/types/variable.type.ts
@@ -1,0 +1,7 @@
+export interface Variable {
+    id: number;
+    name: string;
+    value: string;
+}
+
+export type VariableCollection = { [name: string]: string; };

--- a/cider-app/src/app/shared/pipes/template-to-html.pipe.ts
+++ b/cider-app/src/app/shared/pipes/template-to-html.pipe.ts
@@ -5,6 +5,7 @@ import * as Handlebars from 'handlebars';
 import { CardTemplate } from 'src/app/data-services/types/card-template.type';
 import { Card } from 'src/app/data-services/types/card.type';
 import StringUtils from '../utils/string-utils';
+import { Variable, VariableCollection } from '../../data-services/types/variable.type';
 
 /**
  * Convert a card template into html
@@ -216,23 +217,24 @@ export class CardToHtmlPipe implements PipeTransform {
 
   }
 
-  transform(template: CardTemplate, card: Card, assetUrls?: any, uuid?: string): SafeHtml {
+  transform(template: CardTemplate, card: Card, assetUrls?: any, uuid?: string, variables?: VariableCollection): SafeHtml {
     if (!template || !card) {
       return '';
     }
+
     return this.safeHtmlAndStyle(card, 
-      this.executeHandlebars(template.html, card, assetUrls), 
-      this.executeHandlebars(template.css, card, assetUrls),
+      this.executeHandlebars(template.html, card, assetUrls, variables), 
+      this.executeHandlebars(template.css, card, assetUrls, variables),
       uuid);
   }
 
-  private executeHandlebars(htmlTemplate: string, card: Card, assetUrls?: any): string {
+  private executeHandlebars(htmlTemplate: string, card: Card, assetUrls?: any, variables?: VariableCollection): string {
     if (!htmlTemplate) {
       return '';
     }
     let template = Handlebars.compile(htmlTemplate);
     try {
-      return template({card: card, assets: assetUrls});
+      return template({card: card, assets: assetUrls, variables });
     } catch(error) {
       return '';
     }

--- a/cider-app/src/app/site-content-and-menu/site-content-and-menu.component.ts
+++ b/cider-app/src/app/site-content-and-menu/site-content-and-menu.component.ts
@@ -193,6 +193,12 @@ export class SiteContentAndMenuComponent implements OnInit {
             styleClass: 'assets',
             disabled: this.electronService.isElectron() && !projectHomeUrl && !projectUnsaved,
             routerLink: [`/assets`]
+          }, {
+            label: 'Variables',
+            icon: 'pi pi-pw pi-list',
+            styleClass: 'variables',
+            disabled: this.electronService.isElectron() && !projectHomeUrl && !projectUnsaved,
+            routerLink: [`/variables`]
           }
         ];
     }});

--- a/cider-app/src/app/variables/variables.component.html
+++ b/cider-app/src/app/variables/variables.component.html
@@ -1,0 +1,4 @@
+<app-page-header header="Variables" subheader="List of custom variables available to all templates"></app-page-header>
+<p-card styleClass="page-card">
+    <app-entity-table [service]="variablesService"></app-entity-table>
+</p-card>

--- a/cider-app/src/app/variables/variables.component.spec.ts
+++ b/cider-app/src/app/variables/variables.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VariablesComponent } from './variables.component';
+
+describe('VariablesComponent', () => {
+  let component: VariablesComponent;
+  let fixture: ComponentFixture<VariablesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ VariablesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VariablesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/cider-app/src/app/variables/variables.component.ts
+++ b/cider-app/src/app/variables/variables.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit } from '@angular/core';
+import { VariablesService } from '../data-services/services/variables.service';
+
+@Component({
+  selector: 'app-variables',
+  templateUrl: './variables.component.html',
+  styleUrls: ['./variables.component.scss']
+})
+export class VariablesComponent {
+
+  constructor(public variablesService: VariablesService) { }
+
+}


### PR DESCRIPTION
This PR is an attempt to add basic custom variables which can be reused across templates. These should be named with a valid identifier, and then can be substitued in templates by using `{{ variables.my-variable }}`. These work in both the HTML and CSS parts of the template.

## Example usage

Say you wish to use a specific color to represent a certain class of cards (ie. a Fighter). This colour should be used as the back of the card, as the border on the front of the card, and to colour the text on other cards referencing that type. Custom Variables would allow you to specify the color once and reuse it over any template you wish.

You'd first add a variable named `fighter-color` with a value of `#f00`. then you could use `{{ variables.fighter-color }}` anywhere you need to in both the template's html and the css (ie for the back of the card something like `.card { background-color: {{ variables.fighter-color }}; }`)

## Limitations

This is a really quick basic implementation, just to see if it's something you're interested in. Some enhancements that I think would be required are:

- `Name` validation: Names need to be valid identifiers. `my-variable`, `myvariable`, `MyVariable` are all fine; `my variable` won't work but is currently permitted in the ui
- Uniqueness: Names should really be unique, as is it's possible to add multiple variables with the same name. Currently duplicate variables will overwrite previous versions, which could cause confusion