### PR TITLE
fix: reset transform scale on TTS PNG export to prevent large transparent region

### DIFF
--- a/cider-app/src/app/data-services/services/image-renderer.service.ts
+++ b/cider-app/src/app/data-services/services/image-renderer.service.ts
@@ -10,6 +10,8 @@ export interface ImageRendererOptions {
     filter?: (node: HTMLElement) => boolean;
     onImageErrorHandler?: (error: any) => void;
     style?: any;
+    width?: number;
+    height?: number;
 }
 
 @Injectable({
@@ -31,11 +33,19 @@ export class ImageRendererService {
             return domToImageMore.toPng(node, {
                 filter: options?.filter,
                 scale: options?.pixelRatio || 1,
-                style: options?.style
+                style: options?.style,
+                width: options?.width,
+                height: options?.height
             });
         } else {
             // Default to html-to-image
-            return htmlToImage.toPng(node, options);
+            return htmlToImage.toPng(node, {
+                pixelRatio: options?.pixelRatio,
+                filter: options?.filter,
+                style: options?.style,
+                width: options?.width,
+                height: options?.height
+            });
         }
     }
 }

--- a/cider-app/src/app/export-cards/export-cards.component.scss
+++ b/cider-app/src/app/export-cards/export-cards.component.scss
@@ -103,15 +103,18 @@ $preview-individual-scale: 0.08;
             background-color: white;
             overflow: hidden;
             transform-origin: top left;
+            position: relative;
 
             .preview-sheet {
                 width: 100%;
-                height: 100%;
+                min-height: 100%;
                 overflow: visible;
+                position: relative;
 
                 display: flex;
                 flex-wrap: wrap;
                 align-content: flex-start;
+                justify-content: flex-start;
 
                 .card-wrapper {
                     display: inline-block;

--- a/cider-app/src/app/export-cards/export-cards.component.ts
+++ b/cider-app/src/app/export-cards/export-cards.component.ts
@@ -482,8 +482,19 @@ export class ExportCardsComponent implements OnInit, AfterViewChecked {
           this.loadingInfo = 'Generating sheet ' + sheetIndex + ' '
             + (showFront ? 'front' : 'back') + ' image...';
           const cardSheet = this.cardSheets.first;
+          const sheetWidth = this.selectedPaper.orientation === 'portrait' ? this.paperWidth * this.paperDpi : this.paperHeight * this.paperDpi;
+          const sheetHeight = this.selectedPaper.orientation === 'portrait' ? this.paperHeight * this.paperDpi : this.paperWidth * this.paperDpi;
           const imgUri = await limit(() => this.imageRendererService.toPng((<any>cardSheet).nativeElement,
-            { pixelRatio: this.pixelRatio }));
+            { 
+              pixelRatio: this.pixelRatio,
+              width: sheetWidth,
+              height: sheetHeight,
+              style: {
+                backgroundColor: 'white',
+                transform: 'scale(1)',
+                transformOrigin: 'top left'
+              }
+            }));
           const imgName = 'sheet-' + (showFront ? 'front-' : 'back-')
             + sheetIndex + '.png';
           const sheetImage = this.dataUrlToFile(imgUri, imgName);


### PR DESCRIPTION
## Before:
<img width="980" height="676" alt="image" src="https://github.com/user-attachments/assets/98172199-2c8e-4f50-bd95-c9d1b80155f9" />
## After:
<img width="973" height="688" alt="image" src="https://github.com/user-attachments/assets/d771a6df-c82e-44fb-9c44-a8340ba8a463" />

## Problem
In TTS mode, exporting to PNG produces an image where ~90% of the area is transparent. The card sheet only appears in the top-left corner.
## Root Cause
The `#cardSheets` element has a CSS `transform: scale(N)` applied for preview scaling. When `html-to-image` captures the element, it allocates a canvas based on the full layout dimensions (`paperWidth * paperDpi`), but the scaled-down content only occupies the top-left corner — leaving the rest of the canvas transparent.
## Fix
Override `transform: scale(1)` and `transformOrigin: top left` in the `html-to-image` export options so the capture reflects the actual full-size content instead of the scaled preview.